### PR TITLE
3/31 をもって frappy のサービスを終了する

### DIFF
--- a/.github/workflows/node-ci.yaml
+++ b/.github/workflows/node-ci.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Cache node_modules
         id: node_modules_cache_id
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ matrix.os }}-node-v${{ matrix.node }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}

--- a/src/components/molecules/ServiceList/Frappy/index.tsx
+++ b/src/components/molecules/ServiceList/Frappy/index.tsx
@@ -18,9 +18,9 @@ const _Frappy = () => {
         </Styled.TextBox>
       </Styled.Detail>
       <Styled.LinkBox>
-        <Styled.AnchorLink href={FRAPPY_URL} target="_blank" rel="noopener noreferrer">
-          詳しくはこちら
-        </Styled.AnchorLink>
+        <Styled.Link as="button" isDisabled>
+          このサービスは終了しました
+        </Styled.Link>
       </Styled.LinkBox>
     </Styled.Service>
   );

--- a/src/components/molecules/ServiceList/Frappy/index.tsx
+++ b/src/components/molecules/ServiceList/Frappy/index.tsx
@@ -1,7 +1,6 @@
 import { memo } from "react";
 import * as Styled from "../styles";
 
-const FRAPPY_URL = "https://frappy.app/";
 const SERVICE_DESCRIPTION =
   "Frappy(フラッピー)は金曜日の0:00から渋谷エリアで始まる48時間限定の恋活・婚活マッチングアプリです。\n48時間限定のプレッシャーが、最速で意味のある会話と速やかな出会いへと導き「マッチングアプリにおける決定疲れ」を解決することを目的としているサービスです。";
 


### PR DESCRIPTION
### やったこと
- [ ] frappy のサービスを終了する
- [ ] github actions で落ちてしまうため、下記ツールをバージョンアップする
  - [ ] actions/cache@v2 -> actions/cache@v4

--- 
### エビデンス
![image](https://github.com/user-attachments/assets/fb79666f-0d08-4d91-8386-83911c77deb2)
